### PR TITLE
Fix: logout error, localStorage persistence

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -48,6 +48,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await logoutUser(); // Chamar o serviço de logout
       localStorage.removeItem('token');
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('refresh_token');
+      sessionStorage.removeItem('access_token');
+      sessionStorage.removeItem('refresh_token');
+      supabase.auth.signOut(); // Logout do Supabase
       setIsAuthenticated(false);
       setError('');
       setSuccess('Logout realizado com sucesso!');


### PR DESCRIPTION
This pull request updates the `AuthProvider` component in `AuthContext.tsx` to enhance the logout functionality by ensuring all relevant tokens are cleared and the user is signed out from Supabase.

Enhancements to logout functionality:

* [`frontend/src/contexts/AuthContext.tsx`](diffhunk://#diff-cd31910714bcb47bf0c32ff762d1f7d848eb058eb6b93befe3c2aa8c8b4d448cR51-R55): Updated the `logoutUser` function to remove `access_token` and `refresh_token` from both `localStorage` and `sessionStorage`, and added a call to `supabase.auth.signOut()` to handle Supabase-specific logout.