### PR TITLE
Ending User Screen

### DIFF
--- a/frontend/src/components/home/userProfile/UserProfile.tsx
+++ b/frontend/src/components/home/userProfile/UserProfile.tsx
@@ -38,8 +38,8 @@ const UserProfile: React.FC = () => {
          // Atualizar o estado do usuário com os novos dados
          setUser({
            ...userData,
-           recipeCount,
-           favoriteCount,
+           recipeCount: recipeCount.count,
+           favoriteCount : favoriteCount.count,
          });
       } catch (error) {
         setError("Erro ao buscar usuário");
@@ -193,7 +193,7 @@ const UserProfile: React.FC = () => {
                       <div className="flex justify-between items-center">
                         <span className="text-gray-600">Receitas Criadas</span>
                         <span className="font-medium">
-                          {0}
+                          {user.recipeCount}
                         </span>
                       </div>
                       <div className="w-full bg-gray-200 rounded-full h-2.5">
@@ -208,7 +208,7 @@ const UserProfile: React.FC = () => {
                           Receitas Favoritas
                         </span>
                         <span className="font-medium">
-                          {0}
+                          {user.favoriteCount}
                         </span>
                       </div>
                       <div className="w-full bg-gray-200 rounded-full h-2.5">


### PR DESCRIPTION
This pull request updates the `UserProfile` component to correctly display the user's recipe and favorite counts by fixing how these values are assigned and rendered.

### Fixes to user data state and rendering:

* [`frontend/src/components/home/userProfile/UserProfile.tsx`](diffhunk://#diff-282531da5bc719ffd1d65f7c3d3759dd3a2a0fcb5100e387cb246d3568048b1fL41-R42): Updated the `setUser` function to correctly assign `recipeCount` and `favoriteCount` from the API response (`recipeCount.count` and `favoriteCount.count`).
* [`frontend/src/components/home/userProfile/UserProfile.tsx`](diffhunk://#diff-282531da5bc719ffd1d65f7c3d3759dd3a2a0fcb5100e387cb246d3568048b1fL196-R196): Modified the rendering of the "Receitas Criadas" section to display the actual `user.recipeCount` instead of a hardcoded `0`.
* [`frontend/src/components/home/userProfile/UserProfile.tsx`](diffhunk://#diff-282531da5bc719ffd1d65f7c3d3759dd3a2a0fcb5100e387cb246d3568048b1fL211-R211): Modified the rendering of the "Receitas Favoritas" section to display the actual `user.favoriteCount` instead of a hardcoded `0`.